### PR TITLE
Add dot as a valid word seperator for a string key

### DIFF
--- a/Localize.swift
+++ b/Localize.swift
@@ -25,7 +25,7 @@ let relativeSourceFolder = ""
  Those are the regex patterns to recognize localizations.
  */
 let patterns = [
-    "NSLocalizedString\\(@?\"(\\w+)\"", // Swift and Objc Native
+    "NSLocalizedString\\(@?\"([\\w\\.]+)\"", // Swift and Objc Native
     "Localizations\\.((?:[A-Z]{1}[a-z]*[A-z]*)*(?:\\.[A-Z]{1}[a-z]*[A-z]*)*)", // Laurine Calls
     "L10n.tr\\(key: \"(\\w+)\""// SwiftGen generation
 ]


### PR DESCRIPTION
I faced the issue, when the script did not find those strings used which had `dot` in their key, although it is valid when it comes to the Localized Strings. I'm not sure if it's the best solution, or if there are another valid word separators, maybe it could be another configuration.