### PR TITLE
Merge similar NSLocalizedString patterns into one

### DIFF
--- a/Localize.swift
+++ b/Localize.swift
@@ -230,7 +230,7 @@ while let swiftFileLocation = enumerator?.nextObject() as? String {
                                                 range: range,
                                                 using: { (result, _, _) in
                     if let r = result {
-                        let value = (string as NSString).substring(with:r.range(at:1))
+                        let value = (string as NSString).substring(with:r.range(at:r.numberOfRanges-1))
                         localizedStrings.append(value)
                     }
                 })

--- a/Localize.swift
+++ b/Localize.swift
@@ -25,8 +25,7 @@ let relativeSourceFolder = ""
  Those are the regex patterns to recognize localizations.
  */
 let patterns = [
-    "NSLocalizedFormatString\\(@?\"([\\w\\.]+)\"",
-    "NSLocalizedString\\(@?\"([\\w\\.]+)\"", // Swift and Objc Native
+    "NSLocalized(Format)?String\\(@?\"([\\w\\.]+)\"", // Swift and Objc Native
     "Localizations\\.((?:[A-Z]{1}[a-z]*[A-z]*)*(?:\\.[A-Z]{1}[a-z]*[A-z]*)*)", // Laurine Calls
     "L10n.tr\\(key: \"(\\w+)\""// SwiftGen generation
 ]


### PR DESCRIPTION
The NSLocalizedString pattern and the NSLocalizedFormatString pattern, more recently added in #12, are the same except for the name.  Instead of writing them twice with different names we can write the regex once and put the differing part "Format" in an optional group:

    (Format)?

This matches both, without repeating the rest of the pattern.

**Disclaimer:** I'm not an iOS developer, I don't have XCode and I haven't actually run this before submitting the PR, I just really like regular expressions, so please double-check this works as expected before merging 😉